### PR TITLE
Adding Fo/Fc plot for single crystal diffraction

### DIFF
--- a/GSASIIplot.py
+++ b/GSASIIplot.py
@@ -1405,6 +1405,8 @@ def Plot1DSngl(G2frame,newPlot=False,hklRef=None,Super=0,Title=False):
             Page.qaxis = not Page.qaxis
         elif event.key == 'f':
             Page.faxis = not Page.faxis
+        elif event.key == 'v':
+            Page.vaxis = not Page.vaxis
         Draw()
 
     def OnMotion(event):
@@ -1451,29 +1453,55 @@ def Plot1DSngl(G2frame,newPlot=False,hklRef=None,Super=0,Title=False):
         colors=['b','r','g','c','m','k']
         Page.keyPress = OnKeyPress
         
-        if Page.qaxis:
-            Plot.set_xlabel(r'q, '+Angstr+Pwrm1,fontsize=14)
-            X = 2.*np.pi/hklRef.T[4+Super]
-        else:            
-            X = hklRef.T[4+Super]
-        if Page.faxis:
-            Plot.set_ylabel(r'F',fontsize=14)
-            Y = np.nan_to_num(np.sqrt(hklRef.T[8+Super]))
-            Z = np.sqrt(hklRef.T[9+Super])
-        else:            
-            Y = hklRef.T[8+Super]
-            Z = hklRef.T[9+Super]
+        if 'HKLF' in Name:
+            Fosq,sig,Fcsq = hklRef.T[5+Super:8+Super]
+        else:
+            Fosq,sig,Fcsq = hklRef.T[8+Super],1.0,hklRef.T[9+Super]
+
+        d = hklRef.T[4+Super].copy()
+
+        if Page.vaxis:
+            if Page.faxis:
+                Plot.set_xlabel(r'Fc',fontsize=14)
+                Plot.set_ylabel(r'Fo',fontsize=14)
+                X = np.nan_to_num(np.sqrt(Fcsq))
+                Y = np.sqrt(Fosq)
+                Z = 0.5*sig/np.sqrt(Fosq)
+            else:     
+                Plot.set_xlabel(r'Fc'+super2,fontsize=14)
+                Plot.set_ylabel(r'Fo'+super2,fontsize=14)
+                X = Fcsq.copy()
+                Y = Fosq.copy()
+                Z = sig.copy()
+        else:
+            if Page.qaxis:
+                Plot.set_xlabel(r'q, '+Angstr+Pwrm1,fontsize=14)
+                X = 2.*np.pi/d #q
+            else:        
+                X = d #d
+            if Page.faxis:
+                Plot.set_ylabel(r'F',fontsize=14)
+                Y = np.nan_to_num(np.sqrt(Fcsq))
+                Z = np.sqrt(Fosq)
+            else:            
+                Y = Fcsq.copy()
+                Z = Fosq.copy()
         Ymax = np.max(Y)
         
-        XY = np.vstack((X,X,np.zeros_like(X),Y)).reshape((2,2,-1)).T
-        XZ = np.vstack((X,X,np.zeros_like(X),Z)).reshape((2,2,-1)).T
-        XD = np.vstack((X,X,np.zeros_like(X)-Ymax/10.,Y-Z-Ymax/10.)).reshape((2,2,-1)).T
-        lines = mplC.LineCollection(XY,color=colors[0])
-        Plot.add_collection(lines)
-        lines = mplC.LineCollection(XZ,color=colors[1])
-        Plot.add_collection(lines)
-        lines = mplC.LineCollection(XD,color=colors[2])
-        Plot.add_collection(lines)
+        if not Page.vaxis:
+            XY = np.vstack((X,X,np.zeros_like(X),Y)).reshape((2,2,-1)).T
+            XZ = np.vstack((X,X,np.zeros_like(X),Z)).reshape((2,2,-1)).T
+            XD = np.vstack((X,X,np.zeros_like(X)-Ymax/10.,Y-Z-Ymax/10.)).reshape((2,2,-1)).T
+            lines = mplC.LineCollection(XY,color=colors[0])
+            Plot.add_collection(lines)
+            lines = mplC.LineCollection(XZ,color=colors[1])
+            Plot.add_collection(lines)
+            lines = mplC.LineCollection(XD,color=colors[2])
+            Plot.add_collection(lines)
+        else:
+            Plot.errorbar(X, Y, yerr=Z, fmt='.', color='b')
+            Plot.plot(X, X, color='r')
+
         xylim = np.array([[np.min(X),np.max(X)],[np.min(Y-Z-Ymax/10.),np.max(np.concatenate((Y,Z)))]])
         dxylim = np.array([xylim[0][1]-xylim[0][0],xylim[1][1]-xylim[1][0]])/20.
         xylim[0,0] -= dxylim[0]
@@ -1503,11 +1531,12 @@ def Plot1DSngl(G2frame,newPlot=False,hklRef=None,Super=0,Title=False):
         newPlot = True
         Page.qaxis = False
         Page.faxis = False
+        Page.vaxis = False
         Page.canvas.mpl_connect('key_press_event', OnKeyPress)
         Page.canvas.mpl_connect('motion_notify_event', OnMotion)
         Page.Offset = [0,0]
     
-    Page.Choice = (' key press','g: toggle grid','f: toggle Fhkl/F^2hkl plot','q: toggle q/d plot')
+    Page.Choice = (' key press','g: toggle grid','f: toggle Fhkl/F^2hkl plot','q: toggle q/d plot','v: toggle Fo/Fc plot')
     Draw()
     
 #### Plot3DSngl ################################################################################

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # GitDevG2
 Copy of APS svn repository at https://subversion.xray.aps.anl.gov/pyGSAS/
+TESTING FORK

--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 # GitDevG2
 Copy of APS svn repository at https://subversion.xray.aps.anl.gov/pyGSAS/
-TESTING FORK


### PR DESCRIPTION
Updated GSAS-II plotting for single crystal diffraction to show Fo/Fc.

To test:

1. Run GSAS-II and load some single crystal data
2. Click on 1D hkls
![image](https://user-images.githubusercontent.com/13754794/225102596-2481be91-ad9d-4401-a60b-2c1155f7ef94.png)
![image](https://user-images.githubusercontent.com/13754794/225102723-2f655bb1-424d-40fa-9e91-3db43ffd7ddd.png)
3. Type `v` to show versus plot of `Fsqobs vs Fsqcalc`
![image](https://user-images.githubusercontent.com/13754794/225102889-953e8460-a578-4c93-a2ae-7639ed23d8d2.png)
4. Press `f` to toggle between Fsq and F.
![image](https://user-images.githubusercontent.com/13754794/225103044-22b9122e-dc13-403c-8053-1fefa6c70603.png)
5. Toggle back with `v` to ensure previous behavior.
![image](https://user-images.githubusercontent.com/13754794/225103292-e5146c89-6e84-423d-b793-3e7a2972cd8d.png)
